### PR TITLE
Fixes ucsdlib/damsmanager#255 - Support bibs that are longer than 8 digits.

### DIFF
--- a/src/java/edu/ucsd/library/jollyroger/JollyRoger.java
+++ b/src/java/edu/ucsd/library/jollyroger/JollyRoger.java
@@ -109,7 +109,7 @@ public class JollyRoger extends HttpServlet
 		String roger = null;
 		if ( type.equals("bib") )
 		{
-			if ( value.length() > 8 ) { value = value.substring(0,8); }
+			if (value.indexOf("~") > 0) { value = value.substring(0, value.indexOf("~")).trim(); }
 			roger = value;
 			// "/search/.b1234567/.b1234567/1,1,1,B/detlmarc~1234567&FF=&1,0,"
 			query = "/search/." + value + "/." + value + "/1,1,1,B/detlmarc~"


### PR DESCRIPTION
Fixes https://github.com/ucsdlib/damsmanager/issues/255

#### Local Checklist
- [ ] Tests written and passing locally?
- [x] Code style checked?
- [x] QA-ed locally?
- [x] Rebased with `master` branch?
- [ ] Configuration updated (if needed)?
- [ ] Documentation updated (if needed)?

#### What does this PR do?
Support bibs that are longer than 8 digits. For example http://roger.ucsd.edu/record=b10409153~S6.

##### Why are we doing this? Any context of related work?
https://github.com/ucsdlib/damsmanager/issues/255

@ucsdlib/developers - please review
